### PR TITLE
add redirect for workshop interest

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
 	"redirects": [
 		{
 			"source": "/workshop-interest",
-			"destination": "https://docs.google.com/forms/d/1UBgNbERexuKsxU30v-0hInA9R7HZ9JSjqoWN1gdGpQI/viewform?edit_requested=true",
+			"destination": "https://docs.google.com/forms/d/1UBgNbERexuKsxU30v-0hInA9R7HZ9JSjqoWN1gdGpQI/viewform",
 			"permanent": true
 		}
 	]

--- a/vercel.json
+++ b/vercel.json
@@ -16,5 +16,12 @@
 				}
 			]
 		}
+	],
+	"redirects": [
+		{
+			"source": "/workshop-interest",
+			"destination": "https://docs.google.com/forms/d/1UBgNbERexuKsxU30v-0hInA9R7HZ9JSjqoWN1gdGpQI/viewform?edit_requested=true",
+			"permanent": true
+		}
 	]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permanent (301) redirect from /workshop-interest to the workshop interest Google Form for a simple, memorable URL and improved SEO.

* **Chores**
  * Updated deployment configuration to include the new redirect alongside existing site headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->